### PR TITLE
Use pnpm instead of yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,27 +9,27 @@ refs:
     - &Versions
       run:
         name: Versions
-        command: node -v && npm -v && yarn -v
+        command: node -v && npm -v && pnpm -v
     - &Install
       run:
         name: Install Dependencies
-        command: yarn install --pure-lockfile
+        command: pnpm install --frozen-lockfile
     - &Lint
       run:
         name: Lint
-        command: yarn lint
+        command: pnpm lint
     - &Build
       run:
         name: Build
-        command: yarn build
+        command: pnpm build
     - &Build_binaries
       run:
         name: Build binaries
-        command: yarn build:binaries
+        command: pnpm build:binaries
     - &Test
       run:
         name: Test
-        command: yarn test
+        command: pnpm test
     - &Post_to_dev_null
       run:
         name: 'Post to Slack #dev-null'
@@ -61,7 +61,7 @@ jobs:
       - *Post_to_dev_null
       - run:
           name: Release
-          command: yarn release
+          command: pnpm release
       - *Post_to_dev_null
 
   nightly:

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@
 node_modules/
 npm-debug.log
 .vscode/
-yarn-error.log
 dist/
 package-lock.json
 /binaries/
 coverage/
+pnpm-lock.yaml

--- a/.npmignore
+++ b/.npmignore
@@ -5,9 +5,7 @@
 .idea/
 node_modules/
 npm-debug.log
-yarn.lock
 .vscode/
-yarn-error.log
 lib/
 .eslintrs.json
 .nvmrc
@@ -15,7 +13,7 @@ lib/
 index.js
 package-lock.json
 run.js
-yarn.lock
 /test/
 /build/
 /docs/
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "homepage": "https://github.com/streamich/git-cz",
   "license": "Unlicense",
   "scripts": {
-    "lint": "yarn eslint",
+    "lint": "pnpm eslint",
     "clean": "rimraf dist binaries",
-    "build": "yarn build:cli && yarn build:cz",
+    "build": "pnpm build:cli && pnpm build:cz",
     "build:cli": "browserify --node -o dist/cli.js lib/cli.js",
     "build:cz": "browserify --node -o dist/cz.js --standalone prompter lib/cz.js",
     "build:readme": "mmarkdown",
@@ -61,7 +61,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn lint",
+      "pre-commit": "pnpm lint",
       "prepare-commit-msg": "exec < /dev/tty && node ./lib/cli.js --hook || true"
     }
   },


### PR DESCRIPTION
Switch to using `pnpm` instead of `yarn` for package management.

* **package.json**
  - Replace `yarn` commands with `pnpm` equivalents for `lint`, `build`, and `pre-commit` scripts.

* **.circleci/config.yml**
  - Replace `yarn` commands with `pnpm` equivalents for installing dependencies, linting, building, testing, and releasing.

* **.gitignore**
  - Remove `yarn-error.log`.
  - Add `pnpm-lock.yaml`.

* **.npmignore**
  - Remove `yarn.lock` and `yarn-error.log`.
  - Add `pnpm-lock.yaml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/damdauvaotran/git-cz/pull/2?shareId=6e1a55aa-3b18-44df-bbd0-bd62877f9461).