### PR TITLE
fix: 🐛 Fix use wrong number of regex matches

### DIFF
--- a/lib/formatCommitMessage.js
+++ b/lib/formatCommitMessage.js
@@ -23,13 +23,15 @@ const formatCommitMessage = (state) => {
   };
 
   const taskRegex = /feature\/([\w-]+)/gm;
+  const taskMatches = branch.match(taskRegex);
 
   const emoji = config.types[answers.type].emoji;
   const scope = answers.scope ? '(' + answers.scope.trim() + ')' : '';
   const subject = answers.subject.trim();
   const type = answers.type;
   const branch = answers.branch ? answers.branch.trim() : '';
-  const task = branch.match(taskRegex) ? branch.match(taskRegex)[0] : '';
+  const task =
+    Array.isArray(taskMatches) && taskMatches.length > 1 ? branch.match(taskRegex)[1] : '';
 
   const format = config.format || '[{task}] {type}{scope}: {emoji}{subject}';
 

--- a/lib/formatCommitMessage.js
+++ b/lib/formatCommitMessage.js
@@ -23,13 +23,12 @@ const formatCommitMessage = (state) => {
   };
 
   const taskRegex = /feature\/([\w-]+)/gm;
-  const taskMatches = branch.match(taskRegex);
-
   const emoji = config.types[answers.type].emoji;
   const scope = answers.scope ? '(' + answers.scope.trim() + ')' : '';
   const subject = answers.subject.trim();
   const type = answers.type;
   const branch = answers.branch ? answers.branch.trim() : '';
+  const taskMatches = branch.match(taskRegex);
   const task =
     Array.isArray(taskMatches) && taskMatches.length > 1 ? branch.match(taskRegex)[1] : '';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@damdauvaotran/git-cz",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "description": "Semantic emojified git commit, git-cz.",
   "main": "dist/cz.js",
   "bin": {


### PR DESCRIPTION
This pull request includes a few changes to the `lib/formatCommitMessage.js` file and an update to the `package.json` file. The most important changes are:

* [`lib/formatCommitMessage.js`](diffhunk://#diff-9c1ac856813b7750e85daacc0c0172766b2bb4cc9973c7e719db7fb9483ae123R26-R34): Added a new constant `taskMatches` to store the result of the regex match and updated the `task` variable to use this constant, ensuring it correctly assigns the task from the branch name.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version number from `4.8.1` to `4.8.2`.