### PR TITLE
Update readme to guide user install from git-cz to @damdauvaotran/git-cz

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@
 ### Without installation
 
 ```shell
-npx git-cz
+npx @damdauvaotran/git-cz
 # or
-npx git-cz -e
+npx @damdauvaotran/git-cz -e
 ```
 
 ### Install globally standalone
 
 ```shell
-npm install -g git-cz
+npm install -g @damdauvaotran/git-cz
 git-cz
 # or
 git-cz -e
@@ -25,7 +25,7 @@ git-cz -e
 
 ```shell
 npm install -g commitizen
-npm install --save-dev git-cz
+npm install --save-dev @damdauvaotran/git-cz
 ```
 
 `package.json`:
@@ -34,7 +34,7 @@ npm install --save-dev git-cz
 {
   "config": {
     "commitizen": {
-      "path": "git-cz"
+      "path": "@damdauvaotran/git-cz"
     }
   }
 }
@@ -49,8 +49,8 @@ git cz
 ### Install globally with Commitizen
 
 ```shell
-npm install -g commitizen git-cz
-commitizen init git-cz --save-dev --save-exact
+npm install -g commitizen @damdauvaotran/git-cz
+commitizen init @damdauvaotran/git-cz --save-dev --save-exact
 ```
 
 run:


### PR DESCRIPTION
Update `README.md` to guide users to install `@damdauvaotran/git-cz` instead of `git-cz`.

* **Without installation**: Update instructions to use `npx @damdauvaotran/git-cz` instead of `npx git-cz`.
* **Install globally standalone**: Update instructions to use `npm install -g @damdauvaotran/git-cz` instead of `npm install -g git-cz`.
* **Install locally with Commitizen**: Update instructions to use `npm install --save-dev @damdauvaotran/git-cz` instead of `npm install --save-dev git-cz`.
* **Install globally with Commitizen**: Update instructions to use `npm install -g commitizen @damdauvaotran/git-cz` instead of `npm install -g commitizen git-cz`.
* **package.json example**: Update to use `@damdauvaotran/git-cz` instead of `git-cz`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/damdauvaotran/git-cz/pull/6?shareId=f5f057d0-44fd-413c-b7d9-b14a452dd79b).